### PR TITLE
HH-69998 log every test error to make caller aware

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hh.ru/gulp-qunit-runner",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "run qunit tests with gulp",
   "main": "gulp-qunit-runner.js",
   "repository": {

--- a/runner.js
+++ b/runner.js
@@ -13,16 +13,16 @@
     var args = system.args;
     var DEFAULT_TIMEOUT_SECONDS = 5;
 
+    // small hack to redirect errors to stderr instead of stdout
+    console.error = function() {
+        system.stderr.write(Array.prototype.join.call(arguments, ' ') + '\n');
+    };
+
     // arg[0]: scriptName, args[1...]: arguments
     if (args.length < 2) {
         console.error('Usage:\n  phantomjs [phantom arguments] runner.js [timeout-in-seconds] <url-of-your-qunit-testsuite> [<url-of-your-qunit-testsuite>...]');
         exit(1);
     }
-
-    // small hack to redirect errors to stderr instead of stdout
-    console.error = function() {
-        system.stderr.write(Array.prototype.join.call(arguments, ' ') + '\n');
-    };
 
     page = require('webpage').create();
 
@@ -150,6 +150,11 @@
 
             if (!result.total) {
                 console.error('No tests were executed. Are you loading tests asynchronously?');
+                exit(1);
+            }
+
+            if (failed) {
+                console.error('some tests were failed in '+ getSuitName(page.url));
             }
 
             if (args.length === 0) {


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-69998

console.error объявлялась после первого использования.
не хватило логирования для упавших тестов

В блоко предпологается сделать вот так:
```js
        .on('error', (error) => {
            errors.push(error);
        })
        .on('close', () => {
            if (errors.length > 0) {
                errors.forEach(common.logError);
                callback(new Error('there were errors during last run'));
                return;
            }
            callback();
        });
```